### PR TITLE
Added https in bibtex entry for citation

### DIFF
--- a/manuscript/09-contribute.Rmd
+++ b/manuscript/09-contribute.Rmd
@@ -29,7 +29,7 @@ Or use the following bibtex entry:
   year       = {2022},
   subtitle   = {A Guide for Making Black Box Models Explainable},
   edition    = {2},
-  url = {christophm.github.io/interpretable-ml-book/}
+  url        = {https://christophm.github.io/interpretable-ml-book}
 }
 ```
 


### PR DESCRIPTION
- Latex does not link urls which does not have http or https. It is needed so that url can be opened by clicking in softcopy of the book(pdf) .